### PR TITLE
Networking Testing - ClientNetwork and ServerNetwork

### DIFF
--- a/messages/DinoYoshi_root.txt
+++ b/messages/DinoYoshi_root.txt
@@ -1,0 +1,2 @@
+root: hello
+root: goodbye

--- a/server.log
+++ b/server.log
@@ -458,3 +458,34 @@ Mon Apr 27 17:02:06 PDT 2026 | REGISTRATION_SUCCESS | sender=10 | recipient=xerp
 Mon Apr 27 17:02:08 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
 Mon Apr 27 17:02:24 PDT 2026 | LOGIN_SUCCESS | sender=xerp | recipient=SERVER | content=login successful
 Mon Apr 27 17:02:28 PDT 2026 | LOGOUT | sender=xerp | recipient=SERVER | content=logout successful
+Tue Apr 28 13:09:05 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Tue Apr 28 13:10:30 PDT 2026 | READ_LOG | sender=12 | recipient=SERVER | content=read logs
+Tue Apr 28 13:10:48 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=d
+Tue Apr 28 13:11:17 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Tue Apr 28 13:13:21 PDT 2026 | LOGIN_SUCCESS | sender=admin | recipient=SERVER | content=login successful
+Tue Apr 28 13:13:25 PDT 2026 | SEARCH | sender=1 | recipient=SERVER | content=d
+Tue Apr 28 13:13:31 PDT 2026 | GROUP_MESSAGE | sender=admin | recipient=DinoYoshi | content=created group
+Tue Apr 28 13:14:24 PDT 2026 | LOGOUT | sender=admin | recipient=SERVER | content=logout successful
+Tue Apr 28 13:14:27 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Tue Apr 28 13:14:31 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Tue Apr 28 13:14:47 PDT 2026 | READ_LOG | sender=12 | recipient=SERVER | content=read logs
+Tue Apr 28 13:15:50 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Tue Apr 28 13:15:57 PDT 2026 | LOGIN_SUCCESS | sender=yourabot | recipient=SERVER | content=login successful
+Tue Apr 28 13:16:03 PDT 2026 | SEARCH | sender=8 | recipient=SERVER | content=w
+Tue Apr 28 13:16:08 PDT 2026 | GROUP_MESSAGE | sender=yourabot | recipient=Wumbo01 | content=created group
+Tue Apr 28 14:49:31 PDT 2026 | LOGOUT | sender=yourabot | recipient=SERVER | content=logout successful
+Tue Apr 28 14:50:06 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Tue Apr 28 14:50:12 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=
+Tue Apr 28 14:50:14 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=d
+Tue Apr 28 14:52:23 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Tue Apr 28 14:52:31 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=d
+Tue Apr 28 14:53:16 PDT 2026 | LOGIN_SUCCESS | sender=DinoYoshi | recipient=SERVER | content=login successful
+Tue Apr 28 14:53:20 PDT 2026 | SEARCH | sender=3 | recipient=SERVER | content=i
+Tue Apr 28 14:54:06 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Tue Apr 28 14:54:10 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=d
+Tue Apr 28 14:57:11 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Tue Apr 28 14:57:15 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=d
+Tue Apr 28 14:57:20 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=DinoYoshi | content=created group
+Tue Apr 28 14:57:26 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=DinoYoshi | content=hello
+Tue Apr 28 14:57:28 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=DinoYoshi | content=goodbye
+Tue Apr 28 14:57:39 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful

--- a/src/networking/ClientNetwork.java
+++ b/src/networking/ClientNetwork.java
@@ -13,17 +13,16 @@ public class ClientNetwork {
 	private int serverPort; // Port Number of Server to access.
 	private Socket clientSocket; // Socket which Client uses to connect to a ServerSocket
 	private CLIENTSTATUS status; // Client Current Status
-	private enum CLIENTSTATUS {CONNECTED, DISCONNECTED, NULL}; // Status ENUM
+	public enum CLIENTSTATUS {CONNECTED, DISCONNECTED, NULL}; // Status ENUM
 	
 	private ObjectOutputStream objectOutputStream;
 	private ObjectInputStream objectInputStream;
-	
-	private RequestHandler requestHandler; 
+
 	private User user; 
 	
 	// constructor
 	public ClientNetwork(){
-		serverIP = "192.168.1.70"; // hard connection to 'x' server under 'x' port.
+		serverIP = "192.168.1.70"; // need to change when actually testing
 		serverPort = 7777;
 		status = CLIENTSTATUS.DISCONNECTED; // by default they are not connect until a login attempt is made. 
 	}
@@ -272,13 +271,10 @@ public class ClientNetwork {
 		}
 	}
 	
-	public Request handleRequest(Request req) {
-		return requestHandler.handleRequest(req, clientSocket);
-	}
-	
-	public void sendResponse(Request req) throws IOException{
+	public boolean sendResponse(Request req) throws IOException{
 		objectOutputStream.writeObject(req);
 		objectOutputStream.flush();
+		return true;
 	}
 	
 	// getters

--- a/src/networking/ServerNetwork.java
+++ b/src/networking/ServerNetwork.java
@@ -1,4 +1,4 @@
-// TODO: ServerNetwork and ClientNetwork must be built together.
+
 package networking;
 
 import java.io.EOFException;
@@ -188,7 +188,7 @@ public class ServerNetwork {
 	
 	// ServerNetwork methods
 	
-	public static int getPort() {
+	public int getPort() {
 		return port;
 	}
 

--- a/src/testing/ClientNetworkConstructor.java
+++ b/src/testing/ClientNetworkConstructor.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkConstructor {
+	
+	@DisplayName(value = "ClientNetwork Constructor -> not null")
+	@Test
+	public void ClientNetworkConstructorTest() {
+		ClientNetwork n = new ClientNetwork();
+		assertNotNull(n);
+	}
+	
+}

--- a/src/testing/ClientNetworkGetClientSock.java
+++ b/src/testing/ClientNetworkGetClientSock.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkGetClientSock {
+	
+	@DisplayName(value = "ClientNetwork GetClientSock -> null")
+	@Test
+	public void ClientNetworkGetClientSockTest() {
+		ClientNetwork n = new ClientNetwork();
+		assertNull(n.getClientSocket());
+	}
+	
+}

--- a/src/testing/ClientNetworkGetServerIP.java
+++ b/src/testing/ClientNetworkGetServerIP.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkGetServerIP {
+	
+	@DisplayName(value = "ClientNetwork GetServerIP -> 192.168.1.70")
+	@Test
+	public void ClientNetworkGetServerIPTest() {
+		ClientNetwork n = new ClientNetwork();
+		assertEquals(n.getServerIP(), "192.168.1.70");
+	}
+	
+}

--- a/src/testing/ClientNetworkGetServerPort.java
+++ b/src/testing/ClientNetworkGetServerPort.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkGetServerPort {
+	
+	@DisplayName(value = "ClientNetwork GetServerPort -> 7777")
+	@Test
+	public void ClientNetworkGetServerPortTest() {
+		ClientNetwork n = new ClientNetwork();
+		assertEquals(n.getServerPort(), 7777);
+	}
+	
+}

--- a/src/testing/ClientNetworkGetStatus.java
+++ b/src/testing/ClientNetworkGetStatus.java
@@ -1,0 +1,23 @@
+package testing;
+
+import networking.ClientNetwork;
+import networking.ClientNetwork.CLIENTSTATUS;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkGetStatus {
+	
+	@DisplayName(value = "ClientNetwork GetStatus -> DISCONNECTED")
+	@Test
+	public void ClientNetworkGetStatusTest() {
+		ClientNetwork n = new ClientNetwork();
+		assertEquals(n.getStatus(), CLIENTSTATUS.DISCONNECTED);
+	}
+	
+}

--- a/src/testing/ClientNetworkSetClientSock.java
+++ b/src/testing/ClientNetworkSetClientSock.java
@@ -1,0 +1,28 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.Socket;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkSetClientSock {
+	
+	@DisplayName(value = "ClientNetwork SetClientSock -> not null")
+	@Test
+	public void ClientNetworkSetClientSockTest() {
+		
+		Socket sock = new Socket();
+		ClientNetwork n = new ClientNetwork();
+		n.setClientSocket(sock);
+		assertNotNull(n.getClientSocket());
+		
+	}
+	
+}

--- a/src/testing/ClientNetworkSetIP.java
+++ b/src/testing/ClientNetworkSetIP.java
@@ -1,0 +1,23 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkSetIP {
+	
+	@DisplayName(value = "ClientNetwork SetIP -> 127.0.0.1")
+	@Test
+	public void ClientNetworkSetIPTest() {
+		ClientNetwork n = new ClientNetwork();
+		n.setServerIP("127.0.0.1");
+		assertEquals(n.getServerIP(), "127.0.0.1");
+	}
+	
+}

--- a/src/testing/ClientNetworkSetPort.java
+++ b/src/testing/ClientNetworkSetPort.java
@@ -1,0 +1,23 @@
+package testing;
+
+import networking.ClientNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkSetPort {
+	
+	@DisplayName(value = "ClientNetwork SetServerPort -> 8080")
+	@Test
+	public void ClientNetworkSetServerPortTest() {
+		ClientNetwork n = new ClientNetwork();
+		n.setServerPort(8080);
+		assertEquals(n.getServerPort(), 8080);
+	}
+	
+}

--- a/src/testing/ClientNetworkSetStatus.java
+++ b/src/testing/ClientNetworkSetStatus.java
@@ -1,0 +1,26 @@
+package testing;
+
+import networking.ClientNetwork;
+import networking.ClientNetwork.CLIENTSTATUS;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ClientNetworkSetStatus {
+	
+	@DisplayName(value = "ClientNetwork SetStatus -> CONNECTED")
+	@Test
+	public void ClientNetworkSetStatusTest() {
+		ClientNetwork n = new ClientNetwork();
+		
+		n.setStatus(0);
+		
+		assertEquals(n.getStatus(), CLIENTSTATUS.CONNECTED);
+	}
+	
+}

--- a/src/testing/CommunicationAppTestSuite.java
+++ b/src/testing/CommunicationAppTestSuite.java
@@ -12,6 +12,10 @@ import org.junit.platform.suite.api.SelectClasses;
 	UserIsIT.class, UserSetUsername.class, UserSetUID.class, UserSetPassword.class, UserSetStatus.class, ITUserConstructor.class,
 	ITUserGetITUID.class, RequestConstructor.class, RequestGetUID.class, RequestGetCreatedDate.class, RequestGetData.class,
 	RequestGetSenderType.class, RequestGetRecipientType.class, RequestGetType.class, RequestGetSenderID.class, RequestGetRecipientID.class,
+	ServerNetworkConstructor.class, ServerNetworkGetNumConnections.class, ServerNetworkGetPort.class, ServerNetworkGetStatus.class,
+	ClientNetworkConstructor.class, ClientNetworkGetServerIP.class, ClientNetworkGetServerPort.class, ClientNetworkGetClientSock.class,
+	ClientNetworkGetStatus.class, ClientNetworkSetIP.class, ClientNetworkSetPort.class, ClientNetworkSetClientSock.class, 
+	ClientNetworkSetStatus.class,
 	})
 
 

--- a/src/testing/ServerNetworkConstructor.java
+++ b/src/testing/ServerNetworkConstructor.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ServerNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ServerNetworkConstructor {
+	
+	@DisplayName(value = "ServerNetwork Constructor")
+	@Test
+	public void ServerNetworkConstructorTest() {
+		ServerNetwork n = new ServerNetwork();
+		assertNotNull(n);
+	}
+	
+}

--- a/src/testing/ServerNetworkGetNumConnections.java
+++ b/src/testing/ServerNetworkGetNumConnections.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ServerNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ServerNetworkGetNumConnections {
+	
+	@DisplayName(value = "ServerNetwork NumConnections -> 0")
+	@Test
+	public void ServerNetworkGetNumConnectionsTest() {
+		ServerNetwork n = new ServerNetwork();
+		assertEquals(n.getNumConnections(), 0);
+	}
+	
+}

--- a/src/testing/ServerNetworkGetPort.java
+++ b/src/testing/ServerNetworkGetPort.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ServerNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ServerNetworkGetPort {
+	
+	@DisplayName(value = "ServerNetwork GetPort -> 7777")
+	@Test
+	public void ServerNetworkGetPortTest() {
+		ServerNetwork n = new ServerNetwork();
+		assertEquals(n.getPort(), 7777);
+	}
+	
+}

--- a/src/testing/ServerNetworkGetStatus.java
+++ b/src/testing/ServerNetworkGetStatus.java
@@ -1,0 +1,22 @@
+package testing;
+
+import networking.ServerNetwork;
+
+//import junit.framework.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+public class ServerNetworkGetStatus {
+	
+	@DisplayName(value = "ServerNetwork GetStatus -> NULL")
+	@Test
+	public void ServerNetworkGetStatusTest() {
+		ServerNetwork n = new ServerNetwork();
+		assertNull(n.getStatus());
+	}
+	
+}


### PR DESCRIPTION
Added all applicable JUnit 5 Tests for the ClientNetwork and ServerNetwork classes
ClientNetwork
- Constructor
- Get Client Socket
- Get Server IP
- Get Status
- Set Client Socket
- Set IP
- Set Port
- Set Status
ServerNetwork
- Constructor
- Get Number Connections
- Get Port
- Get Status

Refactored ClientNetwork
- ClientNetwork, removed deprecated method (handleRequest)
- ClientNetwork, made CLIENTSTATUS public (for tests)