### PR TITLE
Group Chat Implementation

### DIFF
--- a/contacts.txt
+++ b/contacts.txt
@@ -1,6 +1,8 @@
-root:DinoYoshi,Clarize,Victor
-DinoYoshi:root
+root:DinoYoshi,Clarize,Victor,Team 7,you and me,party time
+DinoYoshi:root,you and me,party time
 Edward:Clarize
-Clarize:root,DinoYoshi
-Victor:Clarize
-
+Clarize:root,DinoYoshi,Team 7,party time
+Victor:Clarize,Team 7,party time
+admin:party time
+otheradmin:party time
+Darien:party time

--- a/groups.txt
+++ b/groups.txt
@@ -1,0 +1,3 @@
+Team 7:Victor,Clarize,root
+you and me:DinoYoshi,root
+party time:admin,otheradmin,DinoYoshi,Darien,Clarize,Victor,root

--- a/messages/Clarize_root.txt
+++ b/messages/Clarize_root.txt
@@ -1,0 +1,4 @@
+root: hey
+Clarize: hi
+root: test123
+root: test333

--- a/messages/DinoYoshi_root.txt
+++ b/messages/DinoYoshi_root.txt
@@ -4,3 +4,5 @@ root: explode yourself
 DinoYoshi: wtf
 root: grr
 root: zoinks!
+root: konnichiwa
+root: konbanwa

--- a/messages/Team 7.txt
+++ b/messages/Team 7.txt
@@ -1,0 +1,3 @@
+root: fuck my chud life
+Victor: hey man don't say that
+Clarize: yes lets not use offensive language in a school setting

--- a/messages/Victor_root.txt
+++ b/messages/Victor_root.txt
@@ -1,0 +1,3 @@
+root: test
+root: test
+root: eeyaoaw

--- a/messages/party time.txt
+++ b/messages/party time.txt
@@ -1,0 +1,7 @@
+root: its party time
+Darien: no it aint
+Clarize: its coffee time
+DinoYoshi: THE DEATH OF YOUR FRIENDS WILL MAKE YOU DESPAIR
+Victor: hey man; chill out
+admin: why was i added to this. im reporting you all to HR
+root: bold words for someone in sudo rm -rf range

--- a/messages/you and me.txt
+++ b/messages/you and me.txt
@@ -1,0 +1,2 @@
+root: so sillly
+DinoYoshi: im not silly YOU'RE silly

--- a/server.log
+++ b/server.log
@@ -735,3 +735,112 @@ Sat May 02 16:17:15 PDT 2026 | LOGIN_SUCCESS | sender=Victor | recipient=SERVER 
 Sat May 02 16:19:32 PDT 2026 | LOGIN_SUCCESS | sender=Darien | recipient=SERVER | content=login successful
 Sat May 02 16:20:25 PDT 2026 | PRIVATE_MESSAGE | sender=Darien | recipient=admins | content=test
 Sat May 02 16:20:29 PDT 2026 | LOGOUT | sender=Darien | recipient=SERVER | content=logout successful
+Sat May 02 17:03:07 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:03:15 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=Clarize | content=hey
+Sat May 02 17:03:22 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 17:03:25 PDT 2026 | LOGIN_SUCCESS | sender=Clarize | recipient=SERVER | content=login successful
+Sat May 02 17:03:28 PDT 2026 | PRIVATE_MESSAGE | sender=Clarize | recipient=root | content=hi
+Sat May 02 17:03:29 PDT 2026 | LOGOUT | sender=Clarize | recipient=SERVER | content=logout successful
+Sat May 02 17:03:32 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:03:41 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=a
+Sat May 02 17:03:52 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=Victor
+Sat May 02 17:03:57 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=Team 7 | content=created private chat
+Sat May 02 17:04:51 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:05:08 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:05:30 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:05:37 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Sat May 02 17:06:14 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=Team 7 | content=created group
+Sat May 02 17:06:43 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=test
+Sat May 02 17:06:57 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=Victor | content=test
+Sat May 02 17:08:53 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=test
+Sat May 02 17:12:48 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=yo
+Sat May 02 17:13:15 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=what
+Sat May 02 17:13:50 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 17:13:53 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:13:57 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 17:14:08 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:14:12 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 17:14:34 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:16:40 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:22:34 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:46:17 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:46:22 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=Victor | content=test
+Sat May 02 17:46:32 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=DinoYoshi | content=konnichiwa
+Sat May 02 17:46:42 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Sat May 02 17:46:45 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=Team 7 | content=created group
+Sat May 02 17:46:56 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=test
+Sat May 02 17:49:17 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:49:58 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:50:19 PDT 2026 | LOGIN_FAILED | sender=root | recipient=SERVER | content=login failed
+Sat May 02 17:50:23 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:50:32 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=DinoYoshi | content=konbanwa
+Sat May 02 17:50:37 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=Victor | content=eeyaoaw
+Sat May 02 17:50:48 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Sat May 02 17:50:54 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=Team 7 | content=created group
+Sat May 02 17:51:03 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=fuck my chud life
+Sat May 02 17:56:36 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 17:56:41 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=Clarize | content=test123
+Sat May 02 17:56:45 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient=Clarize | content=test333
+Sat May 02 17:56:51 PDT 2026 | READ_LOG | sender=12 | recipient=SERVER | content=read logs
+Sat May 02 17:56:51 PDT 2026 | READ_LOG | sender=12 | recipient=SERVER | content=read logs
+Sat May 02 17:57:04 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=
+Sat May 02 17:57:06 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Sat May 02 17:57:09 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=Team 7 | content=created group
+Sat May 02 17:57:13 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=hoi
+Sat May 02 17:58:11 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:02:37 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 18:02:52 PDT 2026 | LOGIN_SUCCESS | sender=Victor | recipient=SERVER | content=login successful
+Sat May 02 18:02:55 PDT 2026 | SEARCH | sender=6 | recipient=SERVER | content=
+Sat May 02 18:02:56 PDT 2026 | SEARCH | sender=6 | recipient=SERVER | content=t
+Sat May 02 18:02:59 PDT 2026 | SEARCH | sender=6 | recipient=SERVER | content=Team
+Sat May 02 18:03:01 PDT 2026 | SEARCH | sender=6 | recipient=SERVER | content=i
+Sat May 02 18:03:07 PDT 2026 | GROUP_MESSAGE | sender=Victor | recipient=Team 7 | content=created private chat
+Sat May 02 18:06:11 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:06:19 PDT 2026 | SEARCH | sender=12 | recipient=SERVER | content=i
+Sat May 02 18:06:25 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=Team 7 | content=created group
+Sat May 02 18:06:30 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=fuck my chud life
+Sat May 02 18:06:34 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 18:06:37 PDT 2026 | LOGIN_SUCCESS | sender=Victor | recipient=SERVER | content=login successful
+Sat May 02 18:06:42 PDT 2026 | PRIVATE_MESSAGE | sender=Victor | recipient= | content=hey man don't say that
+Sat May 02 18:06:46 PDT 2026 | LOGOUT | sender=Victor | recipient=SERVER | content=logout successful
+Sat May 02 18:06:49 PDT 2026 | LOGIN_FAILED | sender=clarize | recipient=SERVER | content=login failed
+Sat May 02 18:06:54 PDT 2026 | LOGIN_SUCCESS | sender=Clarize | recipient=SERVER | content=login successful
+Sat May 02 18:07:10 PDT 2026 | PRIVATE_MESSAGE | sender=Clarize | recipient= | content=yes lets not use offensive language in a school setting
+Sat May 02 18:07:21 PDT 2026 | LOGOUT | sender=Clarize | recipient=SERVER | content=logout successful
+Sat May 02 18:07:24 PDT 2026 | LOGIN_SUCCESS | sender=Darien | recipient=SERVER | content=login successful
+Sat May 02 18:07:26 PDT 2026 | LOGOUT | sender=Darien | recipient=SERVER | content=logout successful
+Sat May 02 18:07:33 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:07:37 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 18:07:52 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:11:35 PDT 2026 | SEARCH | sender=13 | recipient=SERVER | content=Dino
+Sat May 02 18:11:38 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=you and me | content=created group
+Sat May 02 18:11:46 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=so sillly
+Sat May 02 18:11:52 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 18:11:58 PDT 2026 | LOGIN_SUCCESS | sender=DinoYoshi | recipient=SERVER | content=login successful
+Sat May 02 18:12:05 PDT 2026 | PRIVATE_MESSAGE | sender=DinoYoshi | recipient= | content=im not silly YOU'RE silly
+Sat May 02 18:12:07 PDT 2026 | LOGOUT | sender=DinoYoshi | recipient=SERVER | content=logout successful
+Sat May 02 18:12:09 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:13:12 PDT 2026 | SEARCH | sender=13 | recipient=SERVER | content=i
+Sat May 02 18:13:21 PDT 2026 | GROUP_MESSAGE | sender=root | recipient=party time | content=created group
+Sat May 02 18:13:25 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=its party time
+Sat May 02 18:13:31 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful
+Sat May 02 18:13:34 PDT 2026 | LOGIN_SUCCESS | sender=Darien | recipient=SERVER | content=login successful
+Sat May 02 18:13:38 PDT 2026 | PRIVATE_MESSAGE | sender=Darien | recipient= | content=no it aint
+Sat May 02 18:13:40 PDT 2026 | LOGOUT | sender=Darien | recipient=SERVER | content=logout successful
+Sat May 02 18:13:44 PDT 2026 | LOGIN_SUCCESS | sender=Clarize | recipient=SERVER | content=login successful
+Sat May 02 18:13:51 PDT 2026 | PRIVATE_MESSAGE | sender=Clarize | recipient= | content=its coffee time
+Sat May 02 18:13:52 PDT 2026 | LOGOUT | sender=Clarize | recipient=SERVER | content=logout successful
+Sat May 02 18:14:03 PDT 2026 | LOGIN_FAILED | sender=DinoYoshi | recipient=SERVER | content=login failed
+Sat May 02 18:14:06 PDT 2026 | LOGIN_SUCCESS | sender=DinoYoshi | recipient=SERVER | content=login successful
+Sat May 02 18:14:14 PDT 2026 | PRIVATE_MESSAGE | sender=DinoYoshi | recipient= | content=THE DEATH OF YOUR FRIENDS WILL MAKE YOU DESPAIR
+Sat May 02 18:14:24 PDT 2026 | LOGOUT | sender=DinoYoshi | recipient=SERVER | content=logout successful
+Sat May 02 18:14:28 PDT 2026 | LOGIN_SUCCESS | sender=Victor | recipient=SERVER | content=login successful
+Sat May 02 18:14:34 PDT 2026 | PRIVATE_MESSAGE | sender=Victor | recipient= | content=hey man; chill out
+Sat May 02 18:14:36 PDT 2026 | LOGOUT | sender=Victor | recipient=SERVER | content=logout successful
+Sat May 02 18:14:39 PDT 2026 | LOGIN_SUCCESS | sender=admin | recipient=SERVER | content=login successful
+Sat May 02 18:14:49 PDT 2026 | PRIVATE_MESSAGE | sender=admin | recipient= | content=why was i added to this. im reporting you all to HR
+Sat May 02 18:14:55 PDT 2026 | LOGOUT | sender=admin | recipient=SERVER | content=logout successful
+Sat May 02 18:14:57 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:15:06 PDT 2026 | PRIVATE_MESSAGE | sender=root | recipient= | content=bold words for someone in sudo rm -rf range
+Sat May 02 18:19:19 PDT 2026 | LOGIN_SUCCESS | sender=root | recipient=SERVER | content=login successful
+Sat May 02 18:19:25 PDT 2026 | LOGOUT | sender=root | recipient=SERVER | content=logout successful

--- a/src/server/GroupManager.java
+++ b/src/server/GroupManager.java
@@ -132,4 +132,46 @@ public class GroupManager {
         String trimmed = value.trim();				// removes leading and trailing spaces
         return trimmed.isEmpty() ? null : trimmed;	// returns null for blank text otherwise returns the cleaned text
     }
+    
+    public synchronized void loadGroups(Map<String, List<String>> savedContacts) {
+        groups.clear();
+
+        if (savedContacts == null) {
+            return;
+        }
+
+        for (Map.Entry<String, List<String>> entry : savedContacts.entrySet()) {
+            String owner = normalize(entry.getKey());
+
+            if (owner == null) {
+                continue; 
+            }
+
+            groups.putIfAbsent(owner, new LinkedHashSet<>());
+
+            if (entry.getValue() == null) {
+                continue;
+            }
+
+            for (String contact : entry.getValue()) {
+                String cleanContact = normalize(contact);
+
+                // NEW: skips invalid or self-contact entries while restoring
+                if (cleanContact != null && !owner.equals(cleanContact)) {
+                	groups.get(owner).add(cleanContact);
+                }
+            }
+        }
+    }
+    
+    
+    public synchronized Map<String, List<String>> exportGroups() {
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : groups.entrySet()) {
+            copy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+        }
+
+        return copy;
+    }
 }

--- a/src/server/RequestHandler.java
+++ b/src/server/RequestHandler.java
@@ -34,11 +34,12 @@ public class RequestHandler {
         this.groupManager = new GroupManager();	// creates the group manager
         this.contactManager = new ContactManager(); 			// creates the contact manager
         this.loggingManager = new LoggingManager("server.log"); // creates the logging manager using a simple log file
-        this.storageManager = new StorageManager("ITUsers.txt", "users.txt", "contacts.txt", "messages"); 	// creates the storage manager using a user file and message folder
+        this.storageManager = new StorageManager("groups.txt", "ITUsers.txt", "users.txt", "contacts.txt", "messages"); 	// creates the storage manager using a user file and message folder
         this.connectionManager = new ConnectionManager(); 						// creates the connection manager
         this.auth.loadUsers(this.storageManager.loadUsers()); 					// loads saved users into the authentication manager
         this.auth.loadITUsers(this.storageManager.loadITUsers());				// loads saved ITUsers into the authentication manager
         this.contactManager.importContacts(this.storageManager.loadContacts());	// ***** NEW: restores contacts after boot
+        this.groupManager.loadGroups(this.storageManager.loadGroups());
 
     }
 
@@ -205,6 +206,15 @@ public class RequestHandler {
         String sender = auth.getUsernameById(request.getSenderID());		// resolves the sender username
         
         String[] incomingData = parseTwoValues(request.getData()); // separate the content from the target
+        
+        if(groupManager.groupExists(incomingData[1])) { // its a group chat. do completely different logic.
+        	storageManager.saveGroupMessage(request, auth);
+        	loggingManager.addStructuredLog(LogType.PRIVATE_MESSAGE, sender, "", incomingData[0]);	// logs the private message
+            loggingManager.saveLogs(); // saves the log
+            return createResponse("SUCCESS: group message processed", Request.REQUESTTYPE.SUCCESS, auth.getIdByUsername(incomingData[1]), request.getSenderID());	// returns message success response
+        }
+        
+        // otherwise you continue as a private chat between two users.
         int recip = auth.getIdByUsername(incomingData[1]); // resolve the name to an id, then back to a username.
         
         String recipient = auth.getUsernameById(recip); // resolves the recipient username
@@ -314,9 +324,16 @@ public class RequestHandler {
             return createResponse("ERROR: sender must be logged in to load chat history", Request.REQUESTTYPE.NULL, request.getRecipientID(), request.getSenderID());	// returns login required response
         }	// end logged in check
         
+        //
+        if(groupManager.groupExists(request.getData())) { // load group chat history
+        	List<String> history = storageManager.loadGroupChatHistory(request.getData());
+        	return createResponse(String.join("\n", history), Request.REQUESTTYPE.SUCCESS, request.getRecipientID(), request.getSenderID());	// returns chat history response
+        }
+        
         if(auth.getIdByUsername(request.getData()) == null){
         	return createResponse("ERROR: chat must be selected to refresh", Request.REQUESTTYPE.NULL, request.getRecipientID(), request.getSenderID());
         }
+        
         
         List<String> history = storageManager.loadChatHistory(request.getSenderID(), auth.getIdByUsername(request.getData()), auth);	// loads chat history from storage
         return createResponse(String.join("\n", history), Request.REQUESTTYPE.SUCCESS, request.getRecipientID(), request.getSenderID());	// returns chat history response
@@ -354,23 +371,35 @@ public class RequestHandler {
         for (String member : members) {	// starts loop through each requested member
             if (!auth.userExists(member)) {	// checks if the requested member is not registered
                 return createResponse("ERROR: group member does not exist " + member, Request.REQUESTTYPE.NULL, -1, request.getSenderID());	// returns missing member response
-            }	// end member exists check
+            }else {
+            	contactManager.addContact(member, groupName);
+            }
         }	// end member validation loop
         
-        boolean created = groupManager.createGroup(groupName, members);	// attempts to create the group
+        boolean created = false;
+        if(members.size() >= 2) {
+        	created = groupManager.createGroup(groupName, members);	// attempts to create the group
+        }
         
         if (created) { // checks if the group was created
         	if(!auth.registerGroup(groupName) && members.size() != 2) return createResponse("ERROR: group name already exists", Request.REQUESTTYPE.NULL, -1, request.getSenderID());	// returns failure response; // treat this as a "user" but no available username/password. This gives it an ID we can use to commune.
         	
         	if(!auth.userExists(groupName)) {storageManager.saveUser(groupName, "iamnotarealuserdonotactuallyloginasme");} // if 
         	
-        	contactManager.addContact(creator, groupName); // add the contact for the creator TODO, the other members need to also recieve the group chat.
+        	storageManager.saveGroups(groupManager.exportGroups());
+        	//contactManager.addContact(creator, groupName); // add the contact for the creator TODO, the other members need to also recieve the group chat.
             storageManager.saveContacts(contactManager.exportContacts());	// ***** NEW: saves the updated contact map
         	loggingManager.addStructuredLog(LogType.GROUP_MESSAGE, creator, groupName, "created group");	// logs successful group creation
             loggingManager.saveLogs(); // s the log
             return createResponse("SUCCESS: group created " + groupName, Request.REQUESTTYPE.SUCCESS, auth.getIdByUsername(groupName), request.getSenderID());	// returns success response
-        }	// end group creation success check
-        return createResponse("ERROR: group was not created", Request.REQUESTTYPE.NULL, -1, request.getSenderID());	// returns failure response
+        }else{
+        	contactManager.addContact(creator, groupName); // add the contact for the creator TODO, the other members need to also recieve the group chat.
+            storageManager.saveContacts(contactManager.exportContacts());	// ***** NEW: saves the updated contact map
+        	loggingManager.addStructuredLog(LogType.GROUP_MESSAGE, creator, groupName, "created private chat");	// logs successful group creation
+            loggingManager.saveLogs(); // s the log
+            return createResponse("SUCCESS: private chat created " + groupName, Request.REQUESTTYPE.SUCCESS, auth.getIdByUsername(groupName), request.getSenderID());
+        }
+        
     }
 
     // GETTERS

--- a/src/server/StorageManager.java
+++ b/src/server/StorageManager.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 // CLASS DESCRIPTION:
 // handles user persistence, chat history persistence, contact persistence, and offline message storage
@@ -27,6 +28,7 @@ public class StorageManager {
 	// ATTRIBUTES
     private String userFilePath;							// stores the file path where username and password pairs are saved
     private String ITUserFilePath;							// stores file path for it users
+    private String GroupFilePath;
     
     private String contactsFilePath;						// ***** NEW: stores file path for saved contacts
     
@@ -34,7 +36,8 @@ public class StorageManager {
     private Map<Integer, List<Request>> offlineMessages;	// maps recipient ids to queued Request objects for offline delivery
 
     // CONSTRUCTOR (4 arguments)
-    public StorageManager(String ITUserFilePath, String userFilePath, String contactsFilePath, String messageDirectory) {
+    public StorageManager(String GroupsFilePath, String ITUserFilePath, String userFilePath, String contactsFilePath, String messageDirectory) {
+    	this.GroupFilePath = GroupsFilePath;
     	this.ITUserFilePath = ITUserFilePath;
         this.userFilePath = userFilePath;					// stores the user file path
         this.messageDirectory = messageDirectory;			// stores the message directory path
@@ -126,6 +129,29 @@ public class StorageManager {
             System.out.println("Failed to save message: " + e.getMessage());	// prints the error to the console
         }	// end try-catch block
     }
+    
+ // saves a direct message request into a conversation file
+    public synchronized void saveGroupMessage(Request message, UserAuthenticator auth) {
+        if (message == null) {	// checks if message exists
+        	return;
+        }	// end missing message check
+        
+        String data = message.getData();
+    	String safeData = data == null ? "" : data;	// converts null data to empty text
+        String[] parts = safeData.split(",", 2); 	// splits data into two parts at the first comma
+        String first = parts.length > 0 ? parts[0].trim() : "";		// reads the first parsed value
+        String second = parts.length > 1 ? parts[1].trim() : ""; 	// reads the second parsed value
+        String[] res = new String[] { first, second };						// returns the two parsed values
+    	
+        String filePath = messageDirectory + File.separator + second + ".txt";	// computes the conversation file path
+        
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath, true))) {// opens the conversation file in append mode
+            writer.write(auth.getUsernameById(message.getSenderID()) + ": " + res[0]);	// writes the message in a readable sender to recipient format
+            writer.newLine();		// inserts a newline so each message stays on its own line
+        } catch (IOException e) {	// catches file writing errors
+            System.out.println("Failed to save message: " + e.getMessage());	// prints the error to the console
+        }	// end try-catch block
+    }
 
     // loads direct chat history between two numeric ids
     public synchronized List<String> loadChatHistory(int senderID, int recipientID, UserAuthenticator auth) {
@@ -148,6 +174,27 @@ public class StorageManager {
         return history;	// returns the loaded history lines
     }
 
+    // loads a chat history file from a group
+    public synchronized List<String> loadGroupChatHistory(String senderName) {
+        List<String> history = new ArrayList<>();	// creates the list that will hold the loaded conversation lines
+        String filePath = messageDirectory + File.separator + senderName + ".txt";// computes the same path used during saving
+        File file = new File(filePath);	// creates a File object for the conversation file
+        
+        if (!file.exists()) { 			// checks if the conversation file exists
+            return history; 			// returns an empty list if no history file exists yet
+        }	// end missing file check
+        
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {	// opens the conversation file for reading
+            String line;	// declares a variable for each line read from the file
+            while ((line = reader.readLine()) != null) {	// start loop through every line in the conversation file
+                history.add(line);	// adds the current line into the history list
+            }	// end loop
+        } catch (IOException e) {	// catches file reading errors
+            System.out.println("Failed to load chat history: " + e.getMessage());	// prints the error to the console
+        }	// end try-catch block
+        return history;	// returns the loaded history lines
+    }
+    
     // stores a request for later delivery to an offline recipient
     public synchronized void storeOfflineMessage(int recipientID, Request message) {
         if (message == null) {	// checks if message exists
@@ -177,6 +224,9 @@ public class StorageManager {
     private String buildConversationPath(int senderID, int recipientID, UserAuthenticator auth) {
         String user1 = auth == null ? null : auth.getUsernameById(senderID); 	// resolves the sender id to a username
         String user2 = auth == null ? null : auth.getUsernameById(recipientID); // resolves the recipient id to a username
+        
+        
+        
         
         if (user1 == null) { 			// checks if the sender id could not be resolved
             user1 = "user" + senderID; 	// uses a fallback sender name
@@ -247,4 +297,63 @@ public class StorageManager {
             System.out.println("Failed to save contacts: " + e.getMessage());
         }
     }
+    
+    // appends a group and the members to a file.
+    public synchronized void saveGroups(Map<String, List<String>> groups) {
+    	try (BufferedWriter writer = new BufferedWriter(new FileWriter(GroupFilePath))) {
+            if (groups == null) {
+                return;
+            }
+
+            for (Map.Entry<String, List<String>> entry : groups.entrySet()) {
+                String owner = entry.getKey(); 
+                List<String> values = entry.getValue() == null ?  new ArrayList<>() : entry.getValue();
+
+                writer.write(owner + ":" + String.join(",", values));
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            System.out.println("Failed to save groups: " + e.getMessage());
+        }
+    }
+    
+    public synchronized Map<String, List<String>> loadGroups() {
+        Map<String, List<String>> groups = new LinkedHashMap<>();
+        File file = new File(GroupFilePath);
+
+        if (!file.exists()) { 
+            return groups;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) { 
+            String line; // NEW
+
+            while ((line = reader.readLine()) != null) { 
+                String[] parts = line.split(":", 2); 
+                String owner = parts[0].trim(); 
+                List<String> values = new ArrayList<>();
+
+                if (parts.length > 1 && !parts[1].isBlank()) { 
+                    String[] contactParts = parts[1].split(","); 
+
+                    for (String contact : contactParts) { 
+                        String cleanContact = contact.trim(); 
+                        if (!cleanContact.isEmpty()) { 
+                            values.add(cleanContact); 
+                        } 
+                    } 
+                } 
+
+                if (!owner.isBlank()) { 
+                	groups.put(owner, values); 
+                }
+            } 
+        } catch (IOException e) { 
+            System.out.println("Failed to load contacts: " + e.getMessage()); 
+        } 
+
+        return groups; 
+    }
+    
+    
 }

--- a/src/testing/StorageConstructor.java
+++ b/src/testing/StorageConstructor.java
@@ -12,6 +12,7 @@ public class StorageConstructor {
     @Test
     public void StorageConstructorTest() {
         StorageManager sm = new StorageManager(
+        		"testGroups.txt",
                 "testITUsers.txt",
                 "testusers.txt",
                 "testcontacts.txt",

--- a/src/testing/StorageLoadChatHistory.java
+++ b/src/testing/StorageLoadChatHistory.java
@@ -16,6 +16,7 @@ public class StorageLoadChatHistory {
     @Test
     public void LoadChatHistoryTest() {
         StorageManager sm = new StorageManager(
+        		"testGroups.txt",
                 "testITUsers.txt",
                 "testusers.txt",
                 "testcontacts.txt",

--- a/src/testing/StorageLoadUsers.java
+++ b/src/testing/StorageLoadUsers.java
@@ -12,6 +12,7 @@ public class StorageLoadUsers {
     @Test
     public void LoadUsersTest() {
         StorageManager sm = new StorageManager(
+        		"testGroups.txt",
                 "testITUsers.txt",
                 "testusers.txt",
                 "testcontacts.txt",

--- a/src/testing/StorageOfflineMessages.java
+++ b/src/testing/StorageOfflineMessages.java
@@ -13,6 +13,7 @@ public class StorageOfflineMessages {
     @Test
     public void StoreOfflineMessageTest() {
         StorageManager sm = new StorageManager(
+        		"testGroups.txt",
                 "testITUsers.txt",
                 "testusers.txt",
                 "testcontacts.txt",

--- a/src/testing/StorageSaveMessage.java
+++ b/src/testing/StorageSaveMessage.java
@@ -16,6 +16,7 @@ public class StorageSaveMessage {
     @Test
     public void SaveMessageTest() {
         StorageManager sm = new StorageManager(
+        		"testGroups.txt",
                 "testITUsers.txt",
                 "testusers.txt",
                 "testcontacts.txt",

--- a/src/testing/StorageSaveUser.java
+++ b/src/testing/StorageSaveUser.java
@@ -12,6 +12,7 @@ public class StorageSaveUser {
     @Test
     public void SaveUserTest() {
         StorageManager sm = new StorageManager(
+        		"testGroups.txt",
                 "testITUsers.txt",
                 "testusers.txt",
                 "testcontacts.txt",

--- a/testlog.txt
+++ b/testlog.txt
@@ -1,2 +1,4 @@
 [INFO] hello
 [INFO] hello
+[INFO] hello
+[INFO] hello

--- a/testmessages/clarize_darien.txt
+++ b/testmessages/clarize_darien.txt
@@ -1,1 +1,2 @@
 clarize: hello
+clarize: hello

--- a/testmessages/clarize_victor.txt
+++ b/testmessages/clarize_victor.txt
@@ -1,1 +1,2 @@
 clarize: hello
+clarize: hello

--- a/testusers.txt
+++ b/testusers.txt
@@ -1,2 +1,4 @@
 clarize,1234
 clarize,1234
+clarize,1234
+clarize,1234

--- a/users.txt
+++ b/users.txt
@@ -9,3 +9,6 @@ yourabot,letmein
 Wumbo01,uranium
 eclypse,albinauric
 xerp,derp
+Team 7,iamnotarealuserdonotactuallyloginasme
+you and me,iamnotarealuserdonotactuallyloginasme
+party time,iamnotarealuserdonotactuallyloginasme


### PR DESCRIPTION
RequestHandler
- Updated Constructor to load groups from groups txt
- Updated StorageManager attribute to initialize groups txt
- Modified doSendMessage, doCreateGroup, doChatHistory to account for group chats.

GroupManager
- Implemented exportGroups, and loadGroups

StorageManager
- Implemented saveGroups and loadGroups
- Fixed tests related to the StorageManager's Constructor

Results:
Group data is persistent, users who are added to a group receive the contact regardless of being online/offline. 
Group messaging works across systems and the network. 
Does not impact previous working implementations. 